### PR TITLE
Bump Zeek to v4.2.1

### DIFF
--- a/.github/workflows/dockerized-zeek.yaml
+++ b/.github/workflows/dockerized-zeek.yaml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - version: 4.2.0-0
+          - version: 4.2.1-0
             name: zeek
             lts: false
             tags:
@@ -37,7 +37,7 @@ jobs:
               - latest
               - '4'
               - '4.2'
-              - '4.2.0'
+              - '4.2.1'
           - version: 4.1.1-0
             name: zeek
             lts: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.title="tenzir/dockerized-zeek"
 LABEL org.opencontainers.image.description="Dockerized Zeek"
 
 # The Zeek version according to the official release tags.
-ARG ZEEK_VERSION=4.2.0-0
+ARG ZEEK_VERSION=4.2.1-0
 
 # The mirror where to download DEBs from.
 ARG ZEEK_MIRROR="https://download.zeek.org/binary-packages/Debian_11/amd64"


### PR DESCRIPTION
This PR bumps Zeek to version 4.2.1.
